### PR TITLE
Basic support for error's email sending

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,9 @@ return [
         'html-validator' => true,
         'terminal' => true,
     ],
+    'email' => 'email@domain.com',
+    'emailSnooze' => '5 min',
+    'logDirectory' => __DIR__."/../storage/logs"
 ];
 ```
 

--- a/config/tracy.php
+++ b/config/tracy.php
@@ -31,5 +31,5 @@ return [
     ],
     'email' => 'email@domain.com',
     'emailSnooze' => '5 min',
-    'logDirectory' => __DIR__."/../storage/logs"
+    'logDirectory' => __DIR__.'/../storage/logs'
 ];

--- a/config/tracy.php
+++ b/config/tracy.php
@@ -29,4 +29,7 @@ return [
         'html-validator' => false,
         'terminal' => true,
     ],
+    'email' => 'email@domain.com',
+    'emailSnooze' => '5 min',
+    'logDirectory' => __DIR__."/../storage/logs"
 ];

--- a/src/Contracts/IHandler.php
+++ b/src/Contracts/IHandler.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Recca0120\LaravelTracy\Contracts;
+
+interface IHandler
+{
+
+}

--- a/src/DebuggerManager.php
+++ b/src/DebuggerManager.php
@@ -256,10 +256,16 @@ class DebuggerManager
         return $this->renderBuffer(function () use ($exception) {
             Helpers::improveException($exception);
             $this->blueScreen->render($exception);
-            if (is_null(Debugger::$logDirectory) === false) {
-                $this->logger->log($exception->getMessage(), \Tracy\Logger::EXCEPTION);
-            }
         });
+    }
+
+    /**
+     * @param Exception $exception
+     */
+    public function loggerExceptionHandler(Exception $exception) {
+        if (is_null(Debugger::$logDirectory) === false) {
+            $this->logger->log($exception->getMessage(), \Tracy\Logger::EXCEPTION);
+        }
     }
 
     /**

--- a/src/DebuggerManager.php
+++ b/src/DebuggerManager.php
@@ -96,7 +96,7 @@ class DebuggerManager
         Debugger::$time = $config['currentTime'];
         Debugger::$email = $config['email'];
         Debugger::getLogger()->emailSnooze = $config['emailSnooze'];
-        Debugger::$logDirectory = $config["logDirectory"];
+        Debugger::$logDirectory = $config['logDirectory'];
 
         if (isset(Debugger::$editorMapping) === true) {
             Debugger::$editorMapping = $config['editorMapping'];
@@ -199,6 +199,7 @@ class DebuggerManager
             ini_set('session.use_trans_sid', '0');
             ini_set('session.cookie_path', '/');
             ini_set('session.cookie_httponly', '1');
+            ini_set('session.save_path', storage_path('framework/sessions'));
             session_start();
         }
 
@@ -254,7 +255,7 @@ class DebuggerManager
             Helpers::improveException($exception);
             $this->blueScreen->render($exception);
             if (is_null(Debugger::$logDirectory) === false) {
-                $this->logger->log($exception->getMessage(),\Tracy\Logger::EXCEPTION);
+                $this->logger->log($exception->getMessage(), \Tracy\Logger::EXCEPTION);
             }
         });
     }

--- a/src/DebuggerManager.php
+++ b/src/DebuggerManager.php
@@ -43,6 +43,11 @@ class DebuggerManager
     protected $urlGenerator;
 
     /**
+     * @var \Tracy\Logger
+     */
+    protected $logger;
+
+    /**
      * __construct.
      *
      * @param array $config
@@ -54,6 +59,7 @@ class DebuggerManager
         $this->config = $config;
         $this->bar = $bar ?: Debugger::getBar();
         $this->blueScreen = $blueScreen ?: Debugger::getBlueScreen();
+        $this->logger = Debugger::getLogger();
     }
 
     /**
@@ -76,6 +82,9 @@ class DebuggerManager
             'strictMode' => true,
             'currentTime' => $_SERVER['REQUEST_TIME_FLOAT'] ?: microtime(true),
             'editorMapping' => isset(Debugger::$editorMapping) === true ? Debugger::$editorMapping : [],
+            'email' => null,
+            'emailSnooze' => Debugger::getLogger()->emailSnooze,
+            'logDirectory' => null,
         ], $config);
 
         Debugger::$editor = $config['editor'];
@@ -85,6 +94,9 @@ class DebuggerManager
         Debugger::$showLocation = $config['showLocation'];
         Debugger::$strictMode = $config['strictMode'];
         Debugger::$time = $config['currentTime'];
+        Debugger::$email = $config['email'];
+        Debugger::getLogger()->emailSnooze = $config['emailSnooze'];
+        Debugger::$logDirectory = $config["logDirectory"];
 
         if (isset(Debugger::$editorMapping) === true) {
             Debugger::$editorMapping = $config['editorMapping'];
@@ -241,6 +253,9 @@ class DebuggerManager
         return $this->renderBuffer(function () use ($exception) {
             Helpers::improveException($exception);
             $this->blueScreen->render($exception);
+            if (is_null(Debugger::$logDirectory) === false) {
+                $this->logger->log($exception->getMessage(),\Tracy\Logger::EXCEPTION);
+            }
         });
     }
 

--- a/src/DebuggerManager.php
+++ b/src/DebuggerManager.php
@@ -199,7 +199,9 @@ class DebuggerManager
             ini_set('session.use_trans_sid', '0');
             ini_set('session.cookie_path', '/');
             ini_set('session.cookie_httponly', '1');
-            ini_set('session.save_path', storage_path('framework/sessions'));
+            if (function_exists("storage_path")) {
+                ini_set('session.save_path', storage_path('framework/sessions'));
+            }
             session_start();
         }
 

--- a/src/Exceptions/LoggerHandler.php
+++ b/src/Exceptions/LoggerHandler.php
@@ -11,7 +11,7 @@ use Illuminate\Contracts\Debug\ExceptionHandler;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 
-class Handler implements ExceptionHandler, IHandler
+class LoggerHandler implements ExceptionHandler, IHandler
 {
     /**
      * app exception handler.
@@ -50,7 +50,7 @@ class Handler implements ExceptionHandler, IHandler
     }
 
     /**
-     * Render an exception into an HTTP response.
+     * inject sending of email with error and render an exception into an HTTP response.
      *
      * @param \Illuminate\Http\Request $request
      * @param \Exception $e
@@ -60,11 +60,7 @@ class Handler implements ExceptionHandler, IHandler
     {
         $response = $this->exceptionHandler->render($request, $e);
 
-        if ($this->shouldRenderException($response) === true) {
-            $response->setContent(
-                $this->debuggerManager->exceptionHandler($e)
-            );
-        }
+        $this->debuggerManager->loggerExceptionHandler($e);
 
         return $response;
     }

--- a/src/LaravelTracyServiceProvider.php
+++ b/src/LaravelTracyServiceProvider.php
@@ -2,6 +2,7 @@
 
 namespace Recca0120\LaravelTracy;
 
+use Recca0120\LaravelTracy\Exceptions\LoggerHandler;
 use Tracy\Bar;
 use Tracy\Debugger;
 use Tracy\BlueScreen;
@@ -62,6 +63,12 @@ class LaravelTracyServiceProvider extends ServiceProvider
             });
             $this->handleRoutes($router, Arr::get($config, 'route', []));
             $kernel->prependMiddleware(RenderBar::class);
+        }
+        $enabledMailError = is_null(Arr::get($config, 'email', true)) === false;
+        if ($enabledMailError === true) {
+            $this->app->extend(ExceptionHandler::class, function ($exceptionHandler, $app) {
+                return new LoggerHandler($exceptionHandler, $app[DebuggerManager::class]);
+            });
         }
     }
 

--- a/src/Tracy.php
+++ b/src/Tracy.php
@@ -45,11 +45,12 @@ class Tracy
                 'auth' => true,
                 'terminal' => false,
             ],
+            'logDirectory' => null,
         ], $config);
 
         $mode = $config['enabled'] === true ? Debugger::DEVELOPMENT : Debugger::PRODUCTION;
         $config = DebuggerManager::init($config);
-        Debugger::enable($mode, $config['directory'], $config['email']);
+        Debugger::enable($mode, $config['logDirectory'], $config['email']);
         if (is_null($config['emailSnooze']) === false) {
             Debugger::getLogger()->emailSnooze = $config['emailSnooze'];
         }

--- a/tests/DebuggerManagerTest.php
+++ b/tests/DebuggerManagerTest.php
@@ -28,6 +28,9 @@ class DebuggerManagerTest extends TestCase
             'strictMode' => false,
             'currentTime' => 12345678,
             'editorMapping' => [],
+            'email' => "email@email.email",
+            'emailSnooze' => "2 days",
+            'logDirectory' => null,
         ]);
 
         $this->assertSame($config['editor'], Debugger::$editor);

--- a/tests/DebuggerManagerTest.php
+++ b/tests/DebuggerManagerTest.php
@@ -28,8 +28,8 @@ class DebuggerManagerTest extends TestCase
             'strictMode' => false,
             'currentTime' => 12345678,
             'editorMapping' => [],
-            'email' => "email@email.email",
-            'emailSnooze' => "2 days",
+            'email' => 'email@email.email',
+            'emailSnooze' => '2 days',
             'logDirectory' => null,
         ]);
 

--- a/tests/LaravelTracyServiceProviderTest.php
+++ b/tests/LaravelTracyServiceProviderTest.php
@@ -95,7 +95,7 @@ class LaravelTracyServiceProviderTest extends TestCase
                 return $closure($expression) === "<?php \Tracy\Debugger::barDump({$expression}); ?>";
             }));
 
-        $app->shouldReceive('extend')->once()->with('Illuminate\Contracts\Debug\ExceptionHandler', m::on(function ($closure) use ($app) {
+        $app->shouldReceive('extend')->times(2)->with('Illuminate\Contracts\Debug\ExceptionHandler', m::on(function ($closure) use ($app) {
             $app->shouldReceive('offsetGet')->once()->with('Recca0120\LaravelTracy\DebuggerManager')->andReturn(
                 $debuggerManager = m::mock('Recca0120\LaravelTracy\DebuggerManager')
             );
@@ -103,9 +103,9 @@ class LaravelTracyServiceProviderTest extends TestCase
                 $exceptionHandler = m::mock('Illuminate\Contracts\Debug\ExceptionHandler'),
                 $app
             );
-            $this->assertInstanceOf(\Recca0120\LaravelTracy\Exceptions\Handler::class, $handler);
+            $this->assertInstanceOf(\Recca0120\LaravelTracy\Contracts\IHandler::class, $handler);
 
-            return $handler instanceof \Recca0120\LaravelTracy\Exceptions\Handler;
+            return $handler instanceof \Recca0120\LaravelTracy\Exceptions\Handler || $handler instanceof \Recca0120\LaravelTracy\Exceptions\LoggerHandler;
         }));
 
         $kernel = m::mock('Illuminate\Contracts\Http\Kernel');


### PR DESCRIPTION
i make second error handler, which send mail with error on laravel production mode. To send the mail, it was necessary to enable tracy\logger writes logs.